### PR TITLE
Add Jekyll configuration and layout files for portfolio site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,7 @@ url: "https://highlanderkev.github.io" # Replace with your actual domain if diff
 # Build settings
 plugins:
   - jekyll-feed
-  - jekyll-seo-scripts
+  - jekyll-seo-tag
 
 # Theme settings (assuming a modern theme like 'minima' or similar)
 theme: minima

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,23 @@
+---
+# Jekyll Configuration File
+# This file configures the entire Jekyll site.
+# It should be placed at the root of the repository.
+---
+# Site settings
+title: Kevin Patrick Westropp
+email: kevin@example.com
+description: A portfolio showcasing my work as a developer.
+baseurl: "" # The base URL for the site
+url: "https://highlanderkev.github.io" # Replace with your actual domain if different
+
+# Build settings
+plugins:
+  - jekyll-feed
+  - jekyll-seo-scripts
+
+# Theme settings (assuming a modern theme like 'minima' or similar)
+theme: minima
+
+# Collections and Data
+# Define custom data files here if needed, e.g., projects: ./_data/projects.yml
+# For now, we will rely on manual markdown linking.

--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,6 @@
----
 # Jekyll Configuration File
 # This file configures the entire Jekyll site.
 # It should be placed at the root of the repository.
----
 # Site settings
 title: Kevin Patrick Westropp
 email: kevin@example.com

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -1,21 +1,15 @@
-# Project Data Structure Example
-# This file will hold structured data for all projects.
-# Format: YAML front matter for each project.
-
-# Project 1: Name, Description, Tech Stack, Link
-# ---
-# title: Project Alpha
-# description: A brief overview of the project.
-# tech_stack: [React, Node.js, MongoDB]
-# github_link: https://github.com/user/project-alpha
-# live_demo_link: https://project-alpha.com
-# ---
-
-# Project 2: Name, Description, Tech Stack, Link
-# ---
-# title: Project Beta
-# description: Another exciting project showcase.
-# tech_stack: [Python, Django, PostgreSQL]
-# github_link: https://github.com/user/project-beta
-# live_demo_link: https://project-beta.com
-# ---
+# Project data should be a YAML list of project objects.
+# Each item can use the following schema:
+# - title: Project Alpha
+#   description: A brief overview of the project.
+#   tech_stack: [React, Node.js, MongoDB]
+#   github_link: https://github.com/user/project-alpha
+#   live_demo_link: https://project-alpha.com
+#
+# Example:
+# - title: Project Beta
+#   description: Another exciting project showcase.
+#   tech_stack: [Python, Django, PostgreSQL]
+#   github_link: https://github.com/user/project-beta
+#   live_demo_link: https://project-beta.com
+[]

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -1,0 +1,21 @@
+# Project Data Structure Example
+# This file will hold structured data for all projects.
+# Format: YAML front matter for each project.
+
+# Project 1: Name, Description, Tech Stack, Link
+# ---
+# title: Project Alpha
+# description: A brief overview of the project.
+# tech_stack: [React, Node.js, MongoDB]
+# github_link: https://github.com/user/project-alpha
+# live_demo_link: https://project-alpha.com
+# ---
+
+# Project 2: Name, Description, Tech Stack, Link
+# ---
+# title: Project Beta
+# description: Another exciting project showcase.
+# tech_stack: [Python, Django, PostgreSQL]
+# github_link: https://github.com/user/project-beta
+# live_demo_link: https://project-beta.com
+# ---

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,33 @@
+---
+layout: default
+title: Default Layout
+---
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ page.title }} - {{ site.title }}</title>
+    <!-- Link to your CSS/Theme assets here -->
+    <link rel="stylesheet" href="/assets/css/style.css">
+</head>
+<body>
+    <header>
+        <nav>
+            <a href="/">Home</a>
+            <a href="/projects/">Projects</a>
+            <a href="/skills/">Skills</a>
+            <a href="/blog/">Blog</a>
+        </nav>
+    </header>
+
+    <main>
+        {{ content }}
+    </main>
+
+    <footer>
+        <p>&copy; {{ site.time | date: "%Y" }} {{ site.title }}</p>
+    </footer>
+</body>
+</html>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,7 +9,7 @@ title: Default Layout
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ page.title }} - {{ site.title }}</title>
     <!-- Link to your CSS/Theme assets here -->
-    <link rel="stylesheet" href="/assets/css/style.css">
+    <link rel="stylesheet" href="{{ '/assets/main.css' | relative_url }}">
 </head>
 <body>
     <header>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Default Layout
 ---
 

--- a/index.md
+++ b/index.md
@@ -1,9 +1,5 @@
 ---
-theme: minima
-title: highlanderkev.github.io
-description: A portfolio showcasing my work as a developer.
-author: Kevin Patrick Westropp
-baseurl: "" # The base URL for the site
+title: Welcome to my Portfolio
 permalink: /
 ---
 
@@ -14,10 +10,10 @@ Hi, I'm Kevin Patrick Westropp, a developer passionate about building robust and
 This site showcases my journey through various technologies, from backend systems to modern web applications.
 
 ## 🚀 Featured Projects
-[Link to Projects Page](/projects/)
+[Link to Projects Page]({{ '/projects/' | relative_url }})
 
 ## 🛠️ Skills & Technologies
-[Link to Skills Page](/skills/)
+[Link to Skills Page]({{ '/skills/' | relative_url }})
 
 ## 📰 Blog
 Stay updated with my thoughts and technical deep dives on my blog.

--- a/index.md
+++ b/index.md
@@ -1,0 +1,26 @@
+---
+theme: minima
+title: highlanderkev.github.io
+description: A portfolio showcasing my work as a developer.
+author: Kevin Patrick Westropp
+baseurl: "" # The base URL for the site
+permalink: /
+---
+
+# Welcome to my Portfolio
+
+Hi, I'm Kevin Patrick Westropp, a developer passionate about building robust and scalable software solutions.
+
+This site showcases my journey through various technologies, from backend systems to modern web applications.
+
+## 🚀 Featured Projects
+[Link to Projects Page](/projects/)
+
+## 🛠️ Skills & Technologies
+[Link to Skills Page](/skills/)
+
+## 📰 Blog
+Stay updated with my thoughts and technical deep dives on my blog.
+
+---
+*Built with Jekyll and GitHub Pages.*

--- a/skills.md
+++ b/skills.md
@@ -1,0 +1,27 @@
+---
+layout: default
+title: Skills & Technologies
+---
+
+# 🛠️ My Tech Stack
+
+I am a versatile developer with experience across the full stack. My skills are categorized below for easy reference.
+
+## 💻 Frontend
+*   **React/Next.js**: Building dynamic and performant user interfaces.
+*   **JavaScript/TypeScript**: Core language proficiency for modern web development.
+*   **HTML/CSS**: Semantic structure and modern styling (e.g., Tailwind CSS).
+
+## ⚙️ Backend
+*   **Python**: Experience with frameworks like Django/Flask for robust APIs.
+*   **Node.js**: Building scalable server-side applications.
+*   **REST APIs**: Designing and consuming clean, well-documented APIs.
+
+## 💾 Databases & Data
+*   **MongoDB**: NoSQL document database for flexible data modeling.
+*   **PostgreSQL**: Relational database expertise for structured data integrity.
+*   **Firestore**: Experience with cloud-native, scalable NoSQL solutions.
+
+## ☁️ Cloud & DevOps
+*   **AWS/GCP**: Familiarity with cloud deployment pipelines and services.
+*   **Docker/Containerization**: Containerizing applications for consistent environments.


### PR DESCRIPTION
This pull request sets up the foundational structure for a Jekyll-based developer portfolio site. It introduces key configuration files, a default layout, and initial content pages, establishing the groundwork for further customization and content expansion.

**Site configuration and structure:**
- Added `_config.yml` to configure Jekyll site settings, including site metadata, theme (`minima`), plugins, and build options.
- Introduced a default layout in `_layouts/default.html` with navigation, header, footer, and content placeholders for consistent page structure.

**Content and data organization:**
- Created `index.md` as the homepage, featuring an introduction, links to projects, skills, and blog sections.
- Added `skills.md` to outline categorized technical skills and technologies.
- Provided a sample `_data/projects.yml` file to structure project data for future dynamic project listings.